### PR TITLE
Fixing the zypper refresh command to execute on SLES 15

### DIFF
--- a/client/package/mf-smt-client.changes
+++ b/client/package/mf-smt-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep 13 09:32:44 UTC 2023 - Gaurav <gaurav.kumar4@microfocus.com>
+
+- OCTCR52A775063 : SMT 2.0, "smt-client" output always shows the
+  Patch Status as Unknown for OES2023 SP0; it works for OES2018 SP3
+
+-------------------------------------------------------------------
 Mon Nov 11 12:40:10 UTC 2019 - suresh.hosamani@microfocus.com
 
 - B-137188 : added license

--- a/client/script/patchstatus
+++ b/client/script/patchstatus
@@ -29,7 +29,7 @@ sub jobhandler
   push (@REFcmdArgs, '--no-cd');
   push (@REFcmdArgs, '--non-interactive');
   push (@REFcmdArgs, 'refresh');
-  push (@REFcmdArgs, '--service');
+  push (@REFcmdArgs, '--services');
 
   (my $REFret, my $REFstdout, my $REFstderr) = SMT::Agent::Utils::executeCommand ( $command, undef, @REFcmdArgs );
 


### PR DESCRIPTION
To refresh services before refreshing repos, we were using zypper refresh --service nut this command will not work on SLES 15
so changed service to services 

